### PR TITLE
cache dependencies for the make build cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,22 @@
-# Build the manager binary
-FROM golang:1.21 as manager
+# syntax=docker/dockerfile:1.2
 
-WORKDIR /
+FROM golang:1.21 as builder
 
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN go mod download
+WORKDIR /app
 
-# Copy the go source
+COPY go.mod go.sum ./
+# Cache go modules
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
 COPY cmd cmd
 COPY pkg pkg
 
-RUN CGO_ENABLED=0 go build -a -o manager cmd/main.go
-
-FROM d3fk/kubectl:latest as kubectl
+ARG GO_BUILD_FLAGS=""
+RUN CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o manager cmd/main.go
 
 FROM alpine:latest
 WORKDIR /
-COPY --from=manager /manager .
-COPY --from=kubectl /kubectl /usr/bin/kubectl
+COPY --from=builder /app/manager .
+COPY --from=d3fk/kubectl:latest /kubectl /usr/bin/kubectl
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 IMG ?= kondense/kondense:1.0.1
+GO_BUILD_FLAGS ?=
+
+# Enable Docker BuildKit
+export DOCKER_BUILDKIT=1
 
 all: build
 
 build:
-	docker build -t ${IMG} .
+	docker build --build-arg GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" -t ${IMG} .
 
 load:
 	minikube image load ${IMG}
@@ -16,3 +20,5 @@ undeploy:
 
 push:
 	docker push ${IMG}
+
+.PHONY: all build load deploy undeploy push


### PR DESCRIPTION
usage : 
- `make build` (cache enabled)
- `GO_BUILD_FLAGS="-a" make build` to download all deps